### PR TITLE
"SyntaxError: Unexpected token T" bugfix 

### DIFF
--- a/lib/azure-scripty.js
+++ b/lib/azure-scripty.js
@@ -123,7 +123,6 @@ exports.exec = function exec(cmd, callback) {
         try{
           json = JSON.parse(stdout);
           }catch(parsing_error){
-            /*on "azure account import <file>", it will triger a parsing error*/
             callback(undefined,stdout);
           }
       }

--- a/lib/azure-scripty.js
+++ b/lib/azure-scripty.js
@@ -120,7 +120,12 @@ exports.exec = function exec(cmd, callback) {
       if (stdout == '')
         json=null;
       else {
-        json = JSON.parse(stdout);
+        try{
+          json = JSON.parse(stdout);
+          }catch(parsing_error){
+            /*on "azure account import <file>", it will triger a parsing error*/
+            callback(undefined,stdout);
+          }
       }
 
       callback(undefined,json);


### PR DESCRIPTION
When "account import <file>" is executed,  "JSON.parse(stdout)" fails with "SyntaxError: Unexpected token T" error message.
