### PR TITLE
Bug fix: The "callback" method would be called twice in case of "SyntaxError" exception.

### DIFF
--- a/lib/azure-scripty.js
+++ b/lib/azure-scripty.js
@@ -122,12 +122,11 @@ exports.exec = function exec(cmd, callback) {
       else {
         try{
           json = JSON.parse(stdout);
+          callback(undefined,json);
           }catch(parsing_error){
             callback(undefined,stdout);
           }
       }
-
-      callback(undefined,json);
     }
   });
 }


### PR DESCRIPTION
Bug fix: The "callback" method would be called twice in case of "SyntaxError" exception.
