### PR TITLE
callback invoked twice in case of invalid json returned

### DIFF
--- a/lib/azure-scripty.js
+++ b/lib/azure-scripty.js
@@ -142,6 +142,7 @@ exports.exec = function exec(cmd, callback) {
         catch(parsing_error) 
         {
           callback(parsing_error,stdout);
+          return;
         }
       }
       callback(undefined,json);

--- a/test/azure-scripty.coffee
+++ b/test/azure-scripty.coffee
@@ -15,7 +15,7 @@ scripty.exec = (cmd, callback) ->
   calls++;
   receivedCmds.push(cmd);
   if expectedCmds.length > 0
-    cmd.should.include expectedCmds.pop()
+    cmd.should.containEql expectedCmds.pop()
   callback errors.pop(), results.pop()
   
 describe 'scripty', ->

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---compilers coffee:coffee-script
+--compilers mocha --compilers coffee:coffee-script/register
 --reporter spec


### PR DESCRIPTION
Example: `azure config mode arm` returns text only and the callback is executed twice 
